### PR TITLE
Inherit malformed response error from RuntimeError

### DIFF
--- a/lib/ews/errors.rb
+++ b/lib/ews/errors.rb
@@ -46,7 +46,13 @@ module Viewpoint::EWS::Errors
   class ForbiddenResponseError < ResponseError
   end
 
-  class MalformedResponseError < ResponseError
+  class MalformedResponseError < RuntimeError
+    attr_reader :response
+
+    def initialize(message, response)
+      super(message)
+      @response = response
+    end
   end
 
   class SoapResponseError < ResponseError


### PR DESCRIPTION
This doesn't have properties such as status or respsonse body and so
can't meet the contract required.