### PR TITLE
Delete required attendees

### DIFF
--- a/lib/ews/types/calendar_item.rb
+++ b/lib/ews/types/calendar_item.rb
@@ -88,6 +88,8 @@ module Viewpoint::EWS::Types
         if value.nil? && item_field
           # Build DeleteItemField Change
           item_updates << {delete_item_field: field}
+        elsif value.is_a?(Array) && value.empty?
+          item_updates << {delete_item_field: field}
         elsif attribute == :required_attendees
           # Updating property
           elements = value.map do |attendee|
@@ -107,13 +109,8 @@ module Viewpoint::EWS::Types
             { "Attendee" => { sub_elements: mailbox } }
           end
 
-          if elements.any?
-            item_attributes = { "RequiredAttendees" => { sub_elements: elements } }
-            item_updates << {set_item_field: field.merge(calendar_item: {sub_elements: item_attributes})}
-          else
-            item_updates << {delete_item_field: field }
-          end
-
+          item_attributes = { "RequiredAttendees" => { sub_elements: elements } }
+          item_updates << {set_item_field: field.merge(calendar_item: {sub_elements: item_attributes})}
         elsif attribute == :enhanced_location
           if value[:value] == :delete
             # Deleting property

--- a/lib/ews/types/calendar_item.rb
+++ b/lib/ews/types/calendar_item.rb
@@ -88,9 +88,13 @@ module Viewpoint::EWS::Types
         if value.nil? && item_field
           # Build DeleteItemField Change
           item_updates << {delete_item_field: field}
-        elsif value.is_a?(Array) && value.empty?
-          item_updates << {delete_item_field: field}
         elsif attribute == :required_attendees
+          # Deleting Property
+          if value.empty?
+            item_updates << {delete_item_field: field}
+            return
+          end
+
           # Updating property
           elements = value.map do |attendee|
             mailbox = attendee[:attendee][:mailbox]

--- a/lib/ews/types/calendar_item.rb
+++ b/lib/ews/types/calendar_item.rb
@@ -107,9 +107,13 @@ module Viewpoint::EWS::Types
             { "Attendee" => { sub_elements: mailbox } }
           end
 
-          item_attributes = { "RequiredAttendees" => { sub_elements: elements } }
+          if elements.any?
+            item_attributes = { "RequiredAttendees" => { sub_elements: elements } }
+            item_updates << {set_item_field: field.merge(calendar_item: {sub_elements: item_attributes})}
+          else
+            item_updates << {delete_item_field: field }
+          end
 
-          item_updates << {set_item_field: field.merge(calendar_item: {sub_elements: item_attributes})}
         elsif attribute == :enhanced_location
           if value[:value] == :delete
             # Deleting property


### PR DESCRIPTION
# Problem
When the last RequiredAttendee is deleted from an event, we try to send EWS the update with the element `<RequiredAttendees/>`, a self closing tag.
The EWS schemas (2007, 2013 and O365 variants) all defined `RequiredAttendees` to be a non-empty array of Attendee elements, so the update is rejected as invalid.

# Solution
This PR starts representing an empty RequiredAttendees field as a FieldDeletion, much like when other fields are set to `nil`