### PR TITLE
Separate error for 510 responses

### DIFF
--- a/lib/ews/connection.rb
+++ b/lib/ews/connection.rb
@@ -169,6 +169,8 @@ class Viewpoint::EWS::Connection
       else
         raise Errors::ServerError.new("Internal Server Error. Message: #{resp.body}", resp)
       end
+    when 510
+      raise Errors::NotExtendedResponseError.new("The policy for accessing the resource has not been met in the request.", resp)
     else
       raise Errors::ResponseError.new("HTTP Error Code: #{resp.status}, Msg: #{resp.body}", resp)
     end

--- a/lib/ews/errors.rb
+++ b/lib/ews/errors.rb
@@ -46,6 +46,9 @@ module Viewpoint::EWS::Errors
   class ForbiddenResponseError < ResponseError
   end
 
+  class NotExtendedResponseError < ResponseError
+  end
+
   class MalformedResponseError < RuntimeError
     attr_reader :response
 


### PR DESCRIPTION
Allows specialized handling of requests rejected in this way.