### PR TITLE
Fix convert_id implementation

### DIFF
--- a/lib/ews/convert_accessors.rb
+++ b/lib/ews/convert_accessors.rb
@@ -44,8 +44,9 @@ module Viewpoint::EWS::ConvertAccessors
     rm = resp.response_messages[0]
 
     if(rm && rm.status == 'Success')
-      # @todo create custom response class
-      rm
+      id = rm.message.dig(:elems, :alternate_id, :attribs, :id)
+      raise EwsError, "Could not extract id from response." unless id
+      id
     else
       code = rm.respond_to?(:code) ? rm.code : "Unknown"
       text = rm.respond_to?(:message_text) ? rm.message_text : "Unknown"

--- a/lib/ews/soap/exchange_data_services.rb
+++ b/lib/ews/soap/exchange_data_services.rb
@@ -776,10 +776,10 @@ module Viewpoint::EWS::SOAP
         else
           builder.nbuild.ConvertId {|x|
             builder.nbuild.parent.default_namespace = @default_ns
-            x.parent['DestinationFormat'] = opts[:destination_format].to_s.camel_case
+            x.parent['DestinationFormat'] = camel_case(opts[:destination_format].to_s)
             x.SourceIds { |x|
               x[NS_EWS_TYPES].AlternateId { |x|
-                x.parent['Format'] = opts[:format].to_s.camel_case
+                x.parent['Format'] = camel_case(opts[:format].to_s)
                 x.parent['Id'] = opts[:id]
                 x.parent['Mailbox'] = opts[:mailbox]
               }

--- a/spec/soap_data/convert_id_request.xml
+++ b/spec/soap_data/convert_id_request.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types" xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages">
+  <soap:Header>
+    <t:RequestServerVersion Version="Exchange2013"/>
+  </soap:Header>
+  <soap:Body>
+    <ConvertId xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" DestinationFormat="EntryId">
+      <SourceIds>
+        <t:AlternateId Format="EwsId" Id="AAMkAGQyMmE3ODAxLWZlNTItNDdiZS04NzNhLWQxNWQ4MjUzMzY1YgAuAAAAAADiDiwt8lJHQI9Vqfh/HOkiAQDwNDPGgnbYTa3P6qFapoP/AAAAAAENAAA=" Mailbox="foo@bar.com"/>
+      </SourceIds>
+    </ConvertId>
+  </soap:Body>
+</soap:Envelope>

--- a/spec/soap_data/convert_id_response.xml
+++ b/spec/soap_data/convert_id_response.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+  <s:Header>
+    <h:ServerVersionInfo xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" MajorVersion="15" MinorVersion="20" MajorBuildNumber="4628" MinorBuildNumber="20" Version="V2018_01_08"/>
+  </s:Header>
+  <s:Body>
+    <m:ConvertIdResponse xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">
+      <m:ResponseMessages>
+        <m:ConvertIdResponseMessage ResponseClass="Success">
+          <m:ResponseCode>NoError</m:ResponseCode>
+          <m:AlternateId xsi:type="t:AlternateIdType" Format="EntryId" Id="AAAAAOIOLC3yUkdAj1Wp+H8c6SIBAPA0M8aCdthNrc/qoVqmg/8AAAAAAQ0AAA==" Mailbox="foo@bar.com"/>
+        </m:ConvertIdResponseMessage>
+      </m:ResponseMessages>
+    </m:ConvertIdResponse>
+  </s:Body>
+</s:Envelope>

--- a/spec/unit/convert_accessors_spec.rb
+++ b/spec/unit/convert_accessors_spec.rb
@@ -1,0 +1,34 @@
+require_relative '../spec_helper'
+
+describe Viewpoint::EWS::ConvertAccessors do
+  let(:ews) do
+    con = double('Connection')
+    Viewpoint::EWS::SOAP::ExchangeWebService.new con,
+      {:server_version => Viewpoint::EWS::SOAP::VERSION_2010_SP2}
+  end
+
+  let(:client) do
+    client = double("EWSClient")
+    client.extend subject
+    client.stub(:ews) {ews}
+    client
+  end
+
+  before do
+    ews.stub(:do_soap_request)
+  end
+
+  it "generates ConvertId XML" do
+    ews.should_receive(:do_soap_request).
+      with(match_xml(load_soap("convert_id", :request)))
+
+    id = "AAMkAGQyMmE3ODAxLWZlNTItNDdiZS04NzNhLWQxNWQ4MjUzMzY1YgAuAAAAAADiDiwt8lJHQI9Vqfh/HOkiAQDwNDPGgnbYTa3P6qFapoP/AAAAAAENAAA="
+
+    opts = {
+      format: :ews_id,
+      destination_format: :entry_id,
+      mailbox: 'foo@bar.com',
+    }
+    client.convert_id(id, opts)
+  end
+end

--- a/spec/unit/convert_accessors_spec.rb
+++ b/spec/unit/convert_accessors_spec.rb
@@ -4,24 +4,22 @@ describe Viewpoint::EWS::ConvertAccessors do
   let(:ews) do
     con = double('Connection')
     Viewpoint::EWS::SOAP::ExchangeWebService.new con,
-      {:server_version => Viewpoint::EWS::SOAP::VERSION_2010_SP2}
+      {:server_version => Viewpoint::EWS::SOAP::VERSION_2013}
   end
 
   let(:client) do
     client = double("EWSClient")
-    client.extend subject
+    client.extend described_class
     client.stub(:ews) {ews}
     client
   end
 
-  before do
-    ews.stub(:do_soap_request)
+  let(:response) do
+    Viewpoint::EWS::SOAP::EwsParser.new(load_soap("convert_id", :response))
+      .parse(response_class: Viewpoint::EWS::SOAP::EwsResponse)
   end
 
-  it "generates ConvertId XML" do
-    ews.should_receive(:do_soap_request).
-      with(match_xml(load_soap("convert_id", :request)))
-
+  subject do
     id = "AAMkAGQyMmE3ODAxLWZlNTItNDdiZS04NzNhLWQxNWQ4MjUzMzY1YgAuAAAAAADiDiwt8lJHQI9Vqfh/HOkiAQDwNDPGgnbYTa3P6qFapoP/AAAAAAENAAA="
 
     opts = {
@@ -29,6 +27,21 @@ describe Viewpoint::EWS::ConvertAccessors do
       destination_format: :entry_id,
       mailbox: 'foo@bar.com',
     }
+
     client.convert_id(id, opts)
+  end
+
+  it "generates ConvertId XML" do
+    ews.should_receive(:do_soap_request).
+      with(match_xml(load_soap("convert_id", :request)), response_class: Viewpoint::EWS::SOAP::EwsResponse)
+      .and_return(response)
+
+    subject
+  end
+
+  it "returns the converted ID" do
+    ews.stub(:do_soap_request).and_return(response)
+
+    expect(subject).to eq('AAAAAOIOLC3yUkdAj1Wp+H8c6SIBAPA0M8aCdthNrc/qoVqmg/8AAAAAAQ0AAA==')
   end
 end


### PR DESCRIPTION
This EWS method might make it easier for us to positively identify calendars across Graph and EWS, but it wasn't properly implemented.

Fixes the camel_case monkey patching

Returns the desired ID (or errors) rather than a response XML object