### PR TITLE
SSL legacy server connect

### DIFF
--- a/lib/ews/connection.rb
+++ b/lib/ews/connection.rb
@@ -55,6 +55,7 @@ class Viewpoint::EWS::Connection
 
     @httpcli.ssl_config.verify_mode = opts[:ssl_verify_mode] if opts[:ssl_verify_mode]
     @httpcli.ssl_config.ssl_version = opts[:ssl_version] if opts[:ssl_version]
+    @httpcli.ssl_config.options |= OpenSSL::SSL::OP_LEGACY_SERVER_CONNECT if opts[:ssl_legacy_server_connect]
     # Up the keep-alive so we don't have to do the NTLM dance as often.
     @httpcli.keep_alive_timeout = 60
     @httpcli.connect_timeout = opts[:connect_timeout] if opts[:connect_timeout]


### PR DESCRIPTION
Makes it possible to connect to old Exchange servers that use negotiation mechanisms which have been disabled by default in OpenSSL 3.