### PR TITLE
Guard response code in EwsSoapResponse

### DIFF
--- a/lib/ews/room_accessors.rb
+++ b/lib/ews/room_accessors.rb
@@ -41,7 +41,7 @@ module Viewpoint::EWS::RoomAccessors
     if resp.success?
       resp
     else
-      raise EwsError, "GetRooms produced an error: #{resp.code}: #{resp.message}"
+      raise EwsError, "GetRooms produced an error: #{resp.code}: #{resp.message} [#{resp.response_class}]"
     end
   end
 

--- a/lib/ews/soap/ews_soap_response.rb
+++ b/lib/ews/soap/ews_soap_response.rb
@@ -63,7 +63,7 @@ module Viewpoint::EWS::SOAP
     alias :status :response_class
 
     def response_code
-      response_message[:elems][:response_code][:text]
+      guard_hash response_message[:elems], [:response_code, :text]
     end
     alias :code :response_code
 


### PR DESCRIPTION
Mirrors the handling in ResponseMessage to make enhancing the error message more of a "best effort" when a request has not succeeded rather than potentially failing.