### PR TITLE
Add better malformed response defence to avoid NoMethodErrors

### DIFF
--- a/lib/ews/soap/ews_response.rb
+++ b/lib/ews/soap/ews_response.rb
@@ -114,6 +114,10 @@ module Viewpoint::EWS::SOAP
     end
 
     def get_response_messages(response_type)
+      unless response
+        raise Viewpoint::EWS::Errors::MalformedResponseError.new("body[0] was nil", response)
+      end
+
       unless messages = response[response_type][:elems][0][:response_messages][:elems]
         raise Viewpoint::EWS::Errors::MalformedResponseError.new("Cannot find response_messages child elements", response)
       end

--- a/lib/ews/soap/ews_soap_response.rb
+++ b/lib/ews/soap/ews_soap_response.rb
@@ -48,6 +48,10 @@ module Viewpoint::EWS::SOAP
     end
 
     def response_messages
+      unless response
+        raise Viewpoint::EWS::Errors::MalformedResponseError.new("body[0] was nil", response)
+      end
+
       key = response.keys.first
       response[key][:elems].find{|e| e.keys.include? :response_messages }[:response_messages][:elems]
     end


### PR DESCRIPTION
We're seeing some transitive errors where `response` is nil, so the following `[]` calls cause a NoMethodError.

These errors aren't related to a consistent population of profiles so we can gracefully raise and retry by using the existing `MalformedResponseError`.