### PR TITLE
Dig body to make more of the calls nil-safe

### DIFF
--- a/lib/ews/soap/ews_soap_response.rb
+++ b/lib/ews/soap/ews_soap_response.rb
@@ -44,6 +44,10 @@ module Viewpoint::EWS::SOAP
     end
 
     def response
+      unless body
+        raise Viewpoint::EWS::Errors::MalformedResponseError.new("EWS response missing body - received=#{@resp}", @resp)
+      end
+
       body.dig(0)
     end
 

--- a/lib/ews/soap/ews_soap_response.rb
+++ b/lib/ews/soap/ews_soap_response.rb
@@ -36,15 +36,15 @@ module Viewpoint::EWS::SOAP
     end
 
     def header
-      envelope[0][:header][:elems]
+      envelope.dig(0, :header, :elems)
     end
 
     def body
-      envelope[1][:body][:elems]
+      envelope.dig(1, :body, :elems)
     end
 
     def response
-      body[0]
+      body.dig(0)
     end
 
     def response_messages


### PR DESCRIPTION
Similar to recent changes to rely on `dig`, avoiding more `NoMethodError:[] for nil`

Tested on [NonProd](https://ui.honeycomb.io/cronofy/datasets/cronofy-nonprod/result/2guYNV6oTy1?tab=events) and was still able to sync an EWS calendar