### PR TITLE
Support booking item

### DIFF
--- a/lib/ews/item_accessors.rb
+++ b/lib/ews/item_accessors.rb
@@ -159,7 +159,7 @@ private
 
           # Same handling of GenericFolder#sync_items! to skip booking item
           if Viewpoint::EWS::Types::UNSUPPORTED_ITEM_TYPES.include?(type.to_s.downcase)
-            log.info { "Skipping booking item because it cannot be coerced to a specific type" }
+            log.info { "ItemAccessors#get_items_parser - Skipping booking item because it cannot be coerced to a specific type=#{type.to_s.downcase}" }
             next
           end
 

--- a/lib/ews/item_accessors.rb
+++ b/lib/ews/item_accessors.rb
@@ -158,10 +158,10 @@ private
           type = i.keys.first
 
           # Same handling of GenericFolder#sync_items! to skip booking item
-          if Viewpoint::EWS::Types::UNSUPPORTED_ITEM_TYPES.include?(type.to_s.downcase)
-            log.info { "ItemAccessors#get_items_parser - Skipping booking item because it cannot be coerced to a specific type=#{type.to_s.downcase}" }
-            next
-          end
+          # if Viewpoint::EWS::Types::UNSUPPORTED_ITEM_TYPES.include?(type.to_s.downcase)
+          #   log.info { "ItemAccessors#get_items_parser - Skipping booking item because it cannot be coerced to a specific type=#{type.to_s.downcase}" }
+          #   next
+          # end
 
           items << class_by_name(type).new(ews, i[type])
         end

--- a/lib/ews/item_accessors.rb
+++ b/lib/ews/item_accessors.rb
@@ -163,7 +163,15 @@ private
           #   next
           # end
 
-          items << class_by_name(type).new(ews, i[type])
+          begin
+            items << class_by_name(type).new(ews, i[type])
+          rescue => e
+            log.error { "ItemAccessors#get_items_parser - Failed to parse item - type=#{type} error=#{e.class}, message=#{e.message}" }
+            if type.to_s.downcase == "booking"
+              log.info { "ItemAccesor#get_items_parser - Skip booking item." } 
+              next
+            end
+          end
         end
       end
     end

--- a/lib/ews/item_accessors.rb
+++ b/lib/ews/item_accessors.rb
@@ -160,7 +160,7 @@ private
           if item = parse_item(type, i[type])
             items << item
           else
-            log.info { "Skipping item - type=#{type}"}
+            log.info { "ItemAccessors#get_items_parser - Skipping item - type=#{type}"}
           end
         end
       end
@@ -172,7 +172,7 @@ private
   def parse_item(type, item)
     class_by_name(type).new(ews, item)
   rescue => e
-    log.error { "ItemAccessors#get_items_parser - Failed to parse item - type=#{type} error=#{e.class}, message=#{e.message}" }
+    log.error { "Failed to parse item - type=#{type} error=#{e.class}, message=#{e.message}" }
     unless type.to_s.downcase == "booking"
       raise
     end

--- a/lib/ews/item_accessors.rb
+++ b/lib/ews/item_accessors.rb
@@ -163,20 +163,25 @@ private
           #   next
           # end
 
-          begin
-            items << class_by_name(type).new(ews, i[type])
-          rescue => e
-            log.error { "ItemAccessors#get_items_parser - Failed to parse item - type=#{type} error=#{e.class}, message=#{e.message}" }
-            if type.to_s.downcase == "booking"
-              log.info { "ItemAccesor#get_items_parser - Skip booking item." } 
-              next
-            end
+          if item = parse_item(type, i[type])
+            items << item 
+          else
+            log.info { "Skipping item - type=#{type}"}
           end
         end
       end
     end
 
     items
+  end
+
+  def parse_item(type, item)
+    class_by_name(type).new(ews, item)
+  rescue => e
+    log.error { "ItemAccessors#get_items_parser - Failed to parse item - type=#{type} error=#{e.class}, message=#{e.message}" }
+    unless type.to_s.downcase == "booking"
+      raise
+    end
   end
 
   def find_items_args(opts)

--- a/lib/ews/item_accessors.rb
+++ b/lib/ews/item_accessors.rb
@@ -157,14 +157,8 @@ private
         rm.items.each do |i|
           type = i.keys.first
 
-          # Same handling of GenericFolder#sync_items! to skip booking item
-          # if Viewpoint::EWS::Types::UNSUPPORTED_ITEM_TYPES.include?(type.to_s.downcase)
-          #   log.info { "ItemAccessors#get_items_parser - Skipping booking item because it cannot be coerced to a specific type=#{type.to_s.downcase}" }
-          #   next
-          # end
-
           if item = parse_item(type, i[type])
-            items << item 
+            items << item
           else
             log.info { "Skipping item - type=#{type}"}
           end

--- a/lib/ews/types.rb
+++ b/lib/ews/types.rb
@@ -10,8 +10,6 @@ module Viewpoint::EWS
     }
     KEY_ALIAS = {}
 
-    UNSUPPORTED_ITEM_TYPES = %w(booking).freeze
-
     attr_reader :ews_item
 
     # @param [SOAP::ExchangeWebService] ews the EWS reference

--- a/lib/ews/types/booking.rb
+++ b/lib/ews/types/booking.rb
@@ -1,0 +1,4 @@
+module Viewpoint::EWS::Types
+  class Booking < CalendarItem
+  end
+end

--- a/lib/ews/types/generic_folder.rb
+++ b/lib/ews/types/generic_folder.rb
@@ -208,34 +208,12 @@ module Viewpoint::EWS::Types
             rhash[ctype] << c[ctype][:elems][0][:item_id][:attribs]
           else
             type = c[ctype][:elems][0].keys.first
+
             if id_only_request && type.to_s.downcase == "item"
               log.info { "Skipping item because it cannot be coerced to a specific type" }
               next # We don't have enough detail to coerce this, and we cannot call Item.new
-            # elsif Viewpoint::EWS::Types::UNSUPPORTED_ITEM_TYPES.include?(type.to_s.downcase)
-            #   # Sample booking item
-            #   # {:create=>
-            #   #   {:elems=>
-            #   #     [
-            #   #       {:booking=>
-            #   #         {:elems=>
-            #   #           [
-            #   #             {:item_id=>{:attribs=>{:id=>\"AAMkADM3...\", :change_key=>\"TgAAABYA...\"}}},
-            #   #             {:pre_buffer=>{:text=>\"0\"}},
-            #   #             {:post_buffer=>{:text=>\"0\"}},
-            #   #             {:pricing_type=>{:text=>\"Undefined\"}},
-            #   #             {:price=>{:text=>\"0\"}},
-            #   #             {:booking_fee=>{:text=>\"0\"}},
-            #   #             {:booking_tax=>{:text=>\"0\"}},
-            #   #             {:self_service_id=>{:text=>\"00000000...\"}}
-            #   #           ]
-            #   #         }
-            #   #       }
-            #   #     ]
-            #   #   }
-            #   # }
-            #   log.info { "GenericFolder#sync_items! - Skipping booking item because it cannot be coerced to a specific type=#{type.to_s.downcase}" }
-            #   next
             end
+
             if item = parse_item(type, c[type][:elems][0][type])
               rhash[ctype] << item
             else

--- a/lib/ews/types/generic_folder.rb
+++ b/lib/ews/types/generic_folder.rb
@@ -211,30 +211,30 @@ module Viewpoint::EWS::Types
             if id_only_request && type.to_s.downcase == "item"
               log.info { "Skipping item because it cannot be coerced to a specific type" }
               next # We don't have enough detail to coerce this, and we cannot call Item.new
-            elsif Viewpoint::EWS::Types::UNSUPPORTED_ITEM_TYPES.include?(type.to_s.downcase)
-              # Sample booking item
-              # {:create=>
-              #   {:elems=>
-              #     [
-              #       {:booking=>
-              #         {:elems=>
-              #           [
-              #             {:item_id=>{:attribs=>{:id=>\"AAMkADM3...\", :change_key=>\"TgAAABYA...\"}}},
-              #             {:pre_buffer=>{:text=>\"0\"}},
-              #             {:post_buffer=>{:text=>\"0\"}},
-              #             {:pricing_type=>{:text=>\"Undefined\"}},
-              #             {:price=>{:text=>\"0\"}},
-              #             {:booking_fee=>{:text=>\"0\"}},
-              #             {:booking_tax=>{:text=>\"0\"}},
-              #             {:self_service_id=>{:text=>\"00000000...\"}}
-              #           ]
-              #         }
-              #       }
-              #     ]
-              #   }
-              # }
-              log.info { "GenericFolder#sync_items! - Skipping booking item because it cannot be coerced to a specific type=#{type.to_s.downcase}" }
-              next
+            # elsif Viewpoint::EWS::Types::UNSUPPORTED_ITEM_TYPES.include?(type.to_s.downcase)
+            #   # Sample booking item
+            #   # {:create=>
+            #   #   {:elems=>
+            #   #     [
+            #   #       {:booking=>
+            #   #         {:elems=>
+            #   #           [
+            #   #             {:item_id=>{:attribs=>{:id=>\"AAMkADM3...\", :change_key=>\"TgAAABYA...\"}}},
+            #   #             {:pre_buffer=>{:text=>\"0\"}},
+            #   #             {:post_buffer=>{:text=>\"0\"}},
+            #   #             {:pricing_type=>{:text=>\"Undefined\"}},
+            #   #             {:price=>{:text=>\"0\"}},
+            #   #             {:booking_fee=>{:text=>\"0\"}},
+            #   #             {:booking_tax=>{:text=>\"0\"}},
+            #   #             {:self_service_id=>{:text=>\"00000000...\"}}
+            #   #           ]
+            #   #         }
+            #   #       }
+            #   #     ]
+            #   #   }
+            #   # }
+            #   log.info { "GenericFolder#sync_items! - Skipping booking item because it cannot be coerced to a specific type=#{type.to_s.downcase}" }
+            #   next
             end
             item = class_by_name(type).new(ews, c[ctype][:elems][0][type])
             rhash[ctype] << item

--- a/lib/ews/types/generic_folder.rb
+++ b/lib/ews/types/generic_folder.rb
@@ -236,8 +236,11 @@ module Viewpoint::EWS::Types
             #   log.info { "GenericFolder#sync_items! - Skipping booking item because it cannot be coerced to a specific type=#{type.to_s.downcase}" }
             #   next
             end
-            item = class_by_name(type).new(ews, c[ctype][:elems][0][type])
-            rhash[ctype] << item
+            if item = parse_item(type, c[type][:elems][0][type])
+              rhash[ctype] << item
+            else
+              log.info { "GenericFolder#sync_items - Skipping item type=#{type}"}
+            end
           end
         end
         rhash

--- a/lib/ews/types/generic_folder.rb
+++ b/lib/ews/types/generic_folder.rb
@@ -233,7 +233,7 @@ module Viewpoint::EWS::Types
               #     ]
               #   }
               # }
-              log.info { "Skipping booking item because it cannot be coerced to a specific type" }
+              log.info { "GenericFolder#sync_items! - Skipping booking item because it cannot be coerced to a specific type=#{type.to_s.downcase}" }
               next
             end
             item = class_by_name(type).new(ews, c[ctype][:elems][0][type])

--- a/lib/ews/types/generic_folder.rb
+++ b/lib/ews/types/generic_folder.rb
@@ -214,7 +214,7 @@ module Viewpoint::EWS::Types
               next # We don't have enough detail to coerce this, and we cannot call Item.new
             end
 
-            if item = parse_item(type, c[type][:elems][0][type])
+            if item = parse_item(type, c[ctype][:elems][0][type])
               rhash[ctype] << item
             else
               log.info { "GenericFolder#sync_items - Skipping item type=#{type}"}

--- a/lib/viewpoint.rb
+++ b/lib/viewpoint.rb
@@ -73,6 +73,7 @@ require 'ews/types/search_folder'
 # Items
 require 'ews/types/message'
 require 'ews/types/calendar_item'
+require 'ews/types/booking'
 require 'ews/types/contact'
 require 'ews/types/distribution_list'
 require 'ews/types/meeting_message'


### PR DESCRIPTION
Same response for `CalendarItem` and `Booking` elements
- [sample_booking.json](https://github.com/user-attachments/files/17630488/sample_booking.json)
- [sample_calendar_item.json](https://github.com/user-attachments/files/17630489/sample_calendar_item.json)

The shape of `Booking` is pretty much the same as `CalendarItem`. Basically, we treat Booking as CalendarItem and ignore the following extra attributes.
- pre_buffer
- post_buffer
- pricing_type
- price
- booking_fee
- booking_tax
- self_service_id

Only can find [document](https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/calendaritem) for `CalendarItem`, no mention about `Booking` item.

Here is the [MS Graph API document](https://learn.microsoft.com/en-us/graph/api/resources/bookingappointment?view=graph-rest-1.0) for Booking appointment