### PR TITLE
Extract the booking into a constant for clarification

### DIFF
--- a/lib/ews/item_accessors.rb
+++ b/lib/ews/item_accessors.rb
@@ -174,7 +174,7 @@ private
   rescue => e
     log.error { "Failed to parse item - type=#{type} error=#{e.class}, message=#{e.message}" }
 
-    # skip the error if item is not fully supported
+    # Skipping the error if item is not fully supported and raise error for other types
     unless Viewpoint::EWS::Types::PARTIALLY_SUPPORTED_ITEM_TYPES.include?(type.to_s.downcase)
       raise
     end

--- a/lib/ews/item_accessors.rb
+++ b/lib/ews/item_accessors.rb
@@ -173,7 +173,9 @@ private
     class_by_name(type).new(ews, item)
   rescue => e
     log.error { "Failed to parse item - type=#{type} error=#{e.class}, message=#{e.message}" }
-    unless type.to_s.downcase == "booking"
+
+    # skip the error if item is not fully supported
+    unless Viewpoint::EWS::Types::PARTIALLY_SUPPORTED_ITEM_TYPES.include?(type.to_s.downcase)
       raise
     end
   end

--- a/lib/ews/types.rb
+++ b/lib/ews/types.rb
@@ -10,6 +10,8 @@ module Viewpoint::EWS
     }
     KEY_ALIAS = {}
 
+    PARTIALLY_SUPPORTED_ITEM_TYPES = %w(booking).freeze
+
     attr_reader :ews_item
 
     # @param [SOAP::ExchangeWebService] ews the EWS reference


### PR DESCRIPTION
As per this discussion https://cronofy.slack.com/archives/C06HVC0LS4E/p1730814528559989?thread_ts=1730814304.344029&cid=C06HVC0LS4E, we had previously removed the constant `UNSUPPORTED_ITEMS_TYPES = %w(booking).freeze` but we have reintrouduced this as `PARTIALLY_UNSUPPORTED_ITEM_TYPES` to add further clarification about why we are skipping unsupported types of booking. 